### PR TITLE
Selection bar updates correctly now. 

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -653,7 +653,7 @@ function throttle(func, wait, options) {
      */
     updateSelectionBar: function()
     {
-      this.setWidth(this.selBar, Math.abs(this.maxH.rzsl - this.minH.rzsl));
+      this.setWidth(this.selBar, this.range ? Math.abs(this.maxH.rzsl - this.minH.rzsl) : this.minH.rzsl);
       this.setLeft(this.selBar, this.range ? this.minH.rzsl + this.handleHalfWidth : 0);
     },
 


### PR DESCRIPTION
Bug: Selection bar not updating when this.maxH.rzsl returns NaN. Related to #26