### PR TITLE
Selection bar not updating after rzSliderForceRender (fixed)

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -260,7 +260,7 @@ function throttle(func, wait, options) {
       {
         self.resetLabelsValue();
         thrLow();
-        thrHigh();
+        if(this.range) thrHigh();
         self.resetSlider();
       });
 


### PR DESCRIPTION
After some debugging I found the problem. rzSliderForceRender was calling thrHigh() even when not using range slider.

I guess this is a better fix than the previous one (#48)