### PR TITLE
Ability to pass the template for the slider #49

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -960,7 +960,7 @@ function throttle(func, wait, options) {
   return Slider;
 }])
 
-.directive('rzslider', ['RzSlider', function(Slider)
+.directive('rzslider', ['$compile','RzSlider', function($compile,Slider)
 {
   return {
     restrict: 'E',
@@ -973,7 +973,8 @@ function throttle(func, wait, options) {
       rzSliderHigh: '=?',
       rzSliderTranslate: '&',
       rzSliderHideLimitLabels: '=?',
-      rzSliderAlwaysShowBar: '=?'
+      rzSliderAlwaysShowBar: '=?',
+      rzSliderTemplate: '=?'
     },
     template:   '<span class="rz-bar"></span>' + // 0 The slider bar
                 '<span class="rz-bar rz-selection"></span>' + // 1 Highlight between two handles
@@ -987,6 +988,11 @@ function throttle(func, wait, options) {
 
     link: function(scope, elem, attr)
     {
+      if(scope.rzSliderTemplate !== undefined){
+        template=scope.rzSliderTemplate;
+        elem.html(template);
+        $compile(elem.contents())(scope);
+      }
       return new Slider(scope, elem, attr);
     }
   };


### PR DESCRIPTION
I have done some research regarding #49, and as far as I know there is not way to access the scope in the compile function. Same happens for the template function. You can only access data in $scope inside the LinkingFunction. 

Let me know if you would like to add this feature. I need it for a current project I am working on, so it would be perfect if I could fetch it directly from your repo.

Thank you.