### PR TITLE
Fixes #74: Range Slider - No label if "Min" is the same as "Floor"

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -609,7 +609,7 @@ function throttle(func, wait, options) {
     {
       var delta = Math.abs(this.minH.rzsl - newOffset);
 
-      if(this.minLab.rzsv && delta <= 0 && delta < 1) { return; }
+      if(delta <= 0 && delta < 1) { return; }
 
       this.setLeft(this.minH, newOffset);
       this.translateFn(this.scope.rzSliderModel, this.minLab);

--- a/rzslider.js
+++ b/rzslider.js
@@ -609,7 +609,7 @@ function throttle(func, wait, options) {
     {
       var delta = Math.abs(this.minH.rzsl - newOffset);
 
-      if(delta <= 0 && delta < 1) { return; }
+      if(this.minLab.rzsv && delta <= 0 && delta < 1) { return; }
 
       this.setLeft(this.minH, newOffset);
       this.translateFn(this.scope.rzSliderModel, this.minLab);


### PR DESCRIPTION
Before we stop proceeding because of a small delta, we check if min label already exists or not. If it does not exist, even if delta is small, we proceed so min label can get it's initialize value.