### PR TITLE
Fix delta checking on handle update

### DIFF
--- a/rzslider.js
+++ b/rzslider.js
@@ -609,7 +609,7 @@ function throttle(func, wait, options) {
     {
       var delta = Math.abs(this.minH.rzsl - newOffset);
 
-      if(delta <= 0 && delta < 1) { return; }
+      if(0 <= delta && delta < 1) { return; }
 
       this.setLeft(this.minH, newOffset);
       this.translateFn(this.scope.rzSliderModel, this.minLab);


### PR DESCRIPTION
Very minor, but I assume there was a typo here. A conditional on
```javascript
delta <= 0 && delta < 1
```
makes no sense, because the second statement definitely false if the first is. It seems like you meant to check if the delta was between 0 and 1.