### PR TITLE
Remove invalid text from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $scope.translate = function(value)
 
 ## Slider events
 
-To force slider to recalculate dimensions broadcast **reCalcViewDimensions** event from parent scope. This is useful for example when you use slider with tabs - see *demo/tabs.html* example.
+To force slider to recalculate dimensions broadcast **reCalcViewDimensions** event from parent scope. This is useful for example when you use slider with tabs.
 
 You can also force redraw with **rzSliderForceRender** event.
 


### PR DESCRIPTION
Inside **Slider events** description there was *demo/tabs.html* file mentioned. As this file does not exist, we should remove this part from README.md.