### PR TITLE
Set bower version to 0.1.22

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angularjs-slider",
-  "version": "0.1.21",
+  "version": "0.1.22",
   "homepage": "https://github.com/rzajac/angularjs-slider",
   "authors": [
     "Rafal Zajac <rzajac@gmail.com>",


### PR DESCRIPTION
Fix for the warning I received after installing the latest version:

```bash
$ bower install angularjs-slider
bower angularjs-slider#~0.1.22       not-cached git://github.com/rzajac/angularjs-slider.git#~0.1.22
bower angularjs-slider#~0.1.22          resolve git://github.com/rzajac/angularjs-slider.git#~0.1.22
bower angularjs-slider#*                 cached git://github.com/rzajac/angularjs-slider.git#0.1.21
bower angularjs-slider#*               validate 0.1.21 against git://github.com/rzajac/angularjs-slider.git#*
bower angularjs-slider#~0.1.22         download https://github.com/rzajac/angularjs-slider/archive/0.1.22.tar.gz
bower angularjs-slider#*                    new version for git://github.com/rzajac/angularjs-slider.git#*
bower angularjs-slider#*                resolve git://github.com/rzajac/angularjs-slider.git#*
bower angularjs-slider#*               download https://github.com/rzajac/angularjs-slider/archive/0.1.22.tar.gz
bower angularjs-slider#*                extract archive.tar.gz
bower angularjs-slider#~0.1.22          extract archive.tar.gz
bower angularjs-slider#*               mismatch Version declared in the json (0.1.21) is different than the resolved one (0.1.22)
bower angularjs-slider#~0.1.22         mismatch Version declared in the json (0.1.21) is different than the resolved one (0.1.22)
bower angularjs-slider#~0.1.22         resolved git://github.com/rzajac/angularjs-slider.git#0.1.22
bower angularjs-slider#*               resolved git://github.com/rzajac/angularjs-slider.git#0.1.22
bower angularjs-slider#~0.1.22          install angularjs-slider#0.1.22
```