### PR TITLE
Set 'display:inline-block' to the maximum handle.

### DIFF
--- a/dist/rzslider.js
+++ b/dist/rzslider.js
@@ -458,7 +458,7 @@
         if (!this.range)
           this.maxH.css('display', 'none');
         else
-          this.maxH.css('display', null);
+          this.maxH.css('display', 'inline-block');
 
         this.alwaysHide(this.flrLab, this.options.showTicksValues || this.options.hideLimitLabels);
         this.alwaysHide(this.ceilLab, this.options.showTicksValues || this.options.hideLimitLabels);


### PR DESCRIPTION
Previously, the right handle was being set 'display:null' for a range slider, so set it 'display:inline-block' to make it appear.